### PR TITLE
Fix the format in the header of ECLab.

### DIFF
--- a/python/source/impedance_spectroscopy.py
+++ b/python/source/impedance_spectroscopy.py
@@ -291,7 +291,7 @@ class ECLabAsciiFile(Observer):
 
             # write headers
             for line in self._headers:
-                fout.write(line)
+                fout.write(line.replace('\n','\r\n'))
 
             # write data
             n = subject._data['frequency'].size


### PR DESCRIPTION
This should fix the problem that Frank had. The problem is with the header that are on the linux format instead of the dos format. I was able to fix it in vim but I can check that this patch will work because I can't run jupyter locally. 
