### PR TITLE
Trivial bug fix

### DIFF
--- a/cpp/test/test_impedance_spectroscopy.cc
+++ b/cpp/test/test_impedance_spectroscopy.cc
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE( test_impedance_spectroscopy )
     std::shared_ptr<boost::property_tree::ptree> device_database =
         std::make_shared<boost::property_tree::ptree>(input_database->get_child("device"));
     std::shared_ptr<cap::EnergyStorageDevice> device =
-        cap::buildEnergyStorageDevice(boost::mpi::communicator(), *device_database);
+        cap::EnergyStorageDevice::build(boost::mpi::communicator(), *device_database);
 
     // measure its impedance
     std::fstream fout;


### PR DESCRIPTION
cpp test for impedance spectro only runs when GSL is enabled.
`buildEnergyStorageDevice` was deprecated and it has been removed in a recent
commit.
