### PR TITLE
Check code format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ include(SetupCap)
 if(ENABLE_COVERAGE)
     include(CodeCoverage)
 endif()
+if(ENABLE_AUTO_FORMAT)
+    include(CodeAutoFormat)
+endif()
 
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 

--- a/cmake/CodeAutoFormat.cmake
+++ b/cmake/CodeAutoFormat.cmake
@@ -6,18 +6,6 @@ else()
     message(FATAL_ERROR "-- clang-format not found")
 endif()
 add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/.clang-format
-    DEPENDS ${CMAKE_SOURCE_DIR}/.clang-format
-    COMMAND ${CMAKE_COMMAND}
-    ARGS -E copy ${CMAKE_SOURCE_DIR}/.clang-format
-        ${CMAKE_BINARY_DIR}/.clang-format
-    COMMENT "Copying .clang-format"
-)
-add_custom_target(
-    .clang-format
-    DEPENDS ${CMAKE_BINARY_DIR}/.clang-format
-)
-add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/diff-clang-format.py
     DEPENDS ${CMAKE_SOURCE_DIR}/diff-clang-format.py
     COMMAND ${CMAKE_COMMAND}
@@ -33,9 +21,10 @@ add_custom_target(format-cpp
     ${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/diff-clang-format.py
         --file-extension='.h'
         --file-extension='.cc'
+        --style=file
+        --config="${CMAKE_SOURCE_DIR}/.clang-format"
         ${CMAKE_SOURCE_DIR}/cpp
     DEPENDS
-        ${CMAKE_BINARY_DIR}/.clang-format
         ${CMAKE_BINARY_DIR}/diff-clang-format.py
 )
 

--- a/cmake/CodeAutoFormat.cmake
+++ b/cmake/CodeAutoFormat.cmake
@@ -1,0 +1,55 @@
+## C++ format #################################################################
+find_program(CLANG_FORMAT_EXECUTABLE clang-format)
+if(CLANG_FORMAT_EXECUTABLE)
+    message("-- Found clang-format: ${CLANG_FORMAT_EXECUTABLE}")
+else()
+    message(FATAL_ERROR "-- clang-format not found")
+endif()
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/.clang-format
+    DEPENDS ${CMAKE_SOURCE_DIR}/.clang-format
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -E copy ${CMAKE_SOURCE_DIR}/.clang-format
+        ${CMAKE_BINARY_DIR}/.clang-format
+    COMMENT "Copying .clang-format"
+)
+add_custom_target(
+    .clang-format
+    DEPENDS ${CMAKE_BINARY_DIR}/.clang-format
+)
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/diff-clang-format.py
+    DEPENDS ${CMAKE_SOURCE_DIR}/diff-clang-format.py
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -E copy ${CMAKE_SOURCE_DIR}/diff-clang-format.py
+        ${CMAKE_BINARY_DIR}/diff-clang-format.py
+    COMMENT "Copying diff-clang-format.py"
+)
+add_custom_target(
+    diff-clang-format.py
+    DEPENDS ${CMAKE_BINARY_DIR}/diff-clang-format.py
+)
+add_custom_target(format-cpp
+    ${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/diff-clang-format.py
+        --file-extension='.h'
+        --file-extension='.cc'
+        ${CMAKE_SOURCE_DIR}/cpp
+    DEPENDS
+        ${CMAKE_BINARY_DIR}/.clang-format
+        ${CMAKE_BINARY_DIR}/diff-clang-format.py
+)
+
+## Python format ##############################################################
+find_program(AUTOPEP8_EXECUTABLE autopep8)
+if(AUTOPEP8_EXECUTABLE)
+    message("-- Found autopep8: ${AUTOPEP8_EXECUTABLE}")
+else()
+    message(FATAL_ERROR "-- autopep8 not found")
+endif()
+add_custom_target(format-python
+    ${AUTOPEP8_EXECUTABLE} 
+    --diff ${CMAKE_SOURCE_DIR}/python/source/*.py
+    COMMAND
+    ${AUTOPEP8_EXECUTABLE} 
+    --diff ${CMAKE_SOURCE_DIR}/python/test/*.py
+)

--- a/diff-clang-format.py
+++ b/diff-clang-format.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 '''
-Usage: diff-clang-format.py [--file-extension=<arg>]... [PATHS ...]
+Usage: diff-clang-format.py [--quiet] [--file-extension=<arg>]... [PATHS ...]
 
 Options:
   -h --help               Show this screen
+  -q --quiet              Do not print the diff
   --file-extension=<arg>  File extensions [default: .hpp .cpp]
 '''
 
@@ -45,12 +46,23 @@ def print_diff_with_formatted_source(original_file):
     remove(formatted_file)
     return ostream
 
-if __name__ == '__main__':
-    args = docopt(__doc__)
+def run(paths, file_extensions):
+    ostream = b''
     for path in args['PATHS']:
         for root, dirs, files in walk(path):
             for file in files:
-                if (any([file.endswith(extension) for extension in args['--file-extension']])):
-                    ostream = print_diff_with_formatted_source(root+'/'+file)
-                    if ostream:
-                        print(ostream.decode('utf-8'))
+                if (any([file.endswith(extension) for extension in file_extensions])):
+                    ostream += print_diff_with_formatted_source(root+'/'+file)
+    return ostream
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    ostream = run(args['PATHS'], args['--file-extension'])
+    if ostream:
+        if not args['--quiet']:
+            print(ostream.decode('utf-8'))
+        print('Bad format')
+        exit(1)
+    else:
+        print('OK')
+        exit(0)

--- a/diff-clang-format.py
+++ b/diff-clang-format.py
@@ -1,28 +1,40 @@
 #!/usr/bin/env python
 
 '''
-Usage: diff-clang-format.py [--quiet] [--file-extension=<arg>]... [PATHS ...]
+Usage:
+  diff-clang-format.py [--file-extension=<arg>...] [options] <path>...
 
-Options:
-  -h --help               Show this screen
-  -q --quiet              Do not print the diff
-  --file-extension=<arg>  File extensions [default: .hpp .cpp]
+Option:
+  -h --help                    Show this screen
+  -q --quiet                   Do not print the diff
+  --file-extension=<arg>       Filename extension with a dot [default: .hpp .cpp]
+  --style=<style>              Coding style supportted by clang-format [default: LLVM]
+  --configuration-file=<file>  Style configuation .clang-format file
 '''
 
 from docopt import docopt
 from subprocess import Popen, PIPE
 from os import walk, getcwd, remove
+from shutil import copy
 
-def print_diff_with_formatted_source(original_file):
+def print_diff_with_formatted_source(original_file, style):
     '''Print the diff between the C++ source code and its formatted version
     using clang-format.
+
     Parameters
     ----------
     original_file : str
         Absolute path to the file to be formatted with clang-format.
+    style : str
+        Coding style.
+
+    Returns
+    -------
+    bytes
+        Output of diff.
     '''
     formatted_file = getcwd()+'/'+'.tmp'
-    cmd = ['clang-format', '-style=file', original_file]
+    cmd = ['clang-format', '-style='+style, original_file]
     p = Popen(cmd, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     if p.returncode or stderr:
@@ -46,18 +58,40 @@ def print_diff_with_formatted_source(original_file):
     remove(formatted_file)
     return ostream
 
-def run(paths, file_extensions):
+def run(paths, file_extensions, style, config):
+    '''
+    Parameters
+    ----------
+    paths : list of str
+    file_extensions : list of str
+    style : str
+    config : str or None
+
+    Returns
+    -------
+    bytes
+        Concatenated output of all the diff(s).
+    '''
+    if config:
+        copy(config, getcwd()+'/'+'.clang-format')
+
     ostream = b''
-    for path in args['PATHS']:
+    for path in paths:
         for root, dirs, files in walk(path):
             for file in files:
                 if (any([file.endswith(extension) for extension in file_extensions])):
-                    ostream += print_diff_with_formatted_source(root+'/'+file)
+                    ostream += print_diff_with_formatted_source(root+'/'+file, style)
     return ostream
 
 if __name__ == '__main__':
     args = docopt(__doc__)
-    ostream = run(args['PATHS'], args['--file-extension'])
+
+    paths = args['<path>']
+    extensions = args['--file-extension']
+    style = args['--style']
+    config = args['--configuration-file']
+
+    ostream = run(paths, extensions, style, config)
     if ostream:
         if not args['--quiet']:
             print(ostream.decode('utf-8'))

--- a/diff-clang-format.py
+++ b/diff-clang-format.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+'''
+Usage: diff-clang-format.py [--file-extension=<arg>]... [PATHS ...]
+
+Options:
+  -h --help               Show this screen
+  --file-extension=<arg>  File extensions [default: .hpp .cpp]
+'''
+
+from docopt import docopt
+from subprocess import Popen, PIPE
+from os import walk, getcwd, remove
+
+def print_diff_with_formatted_source(original_file):
+    '''Print the diff between the C++ source code and its formatted version
+    using clang-format.
+    Parameters
+    ----------
+    original_file : str
+        Absolute path to the file to be formatted with clang-format.
+    '''
+    formatted_file = getcwd()+'/'+'.tmp'
+    cmd = ['clang-format', '-style=file', original_file]
+    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate()
+    if p.returncode or stderr:
+        stdout, stderr = p.communicate()
+        raise RuntimeError('clang-format failed')
+    with open(formatted_file, 'wb') as fout:
+        fout.write(stdout)
+    cmd = ['diff', formatted_file, original_file]
+    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate()
+    if stderr:
+        raise RuntimeError('diff failed')
+    ostream = b''
+    if stdout:
+        headers = ''
+        headers += '<<< ' + original_file + '\n'
+        headers += '--- diff ---\n'
+        headers += '>>>' + formatted_file + '\n'
+        ostream += headers.encode('utf-8')
+        ostream += stdout
+    remove(formatted_file)
+    return ostream
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    for path in args['PATHS']:
+        for root, dirs, files in walk(path):
+            for file in files:
+                if (any([file.endswith(extension) for extension in args['--file-extension']])):
+                    ostream = print_diff_with_formatted_source(root+'/'+file)
+                    if ostream:
+                        print(ostream.decode('utf-8'))

--- a/diff-clang-format.py
+++ b/diff-clang-format.py
@@ -8,7 +8,7 @@ Option:
   -h --help                    Show this screen
   -q --quiet                   Do not print the diff
   --file-extension=<arg>       Filename extension with a dot [default: .hpp .cpp]
-  --style=<style>              Coding style supportted by clang-format [default: LLVM]
+  --style=<style>              Coding style supported by clang-format [default: LLVM]
   --configuration-file=<file>  Style configuation .clang-format file
 '''
 
@@ -47,16 +47,8 @@ def diff_with_formatted_source(original_file, style):
     stdout, stderr = p.communicate()
     if stderr:
         raise RuntimeError('diff failed')
-    ostream = b''
-    if stdout:
-        headers = ''
-        headers += '<<< ' + original_file + '\n'
-        headers += '--- diff ---\n'
-        headers += '>>>' + formatted_file + '\n'
-        ostream += headers.encode('utf-8')
-        ostream += stdout
     remove(formatted_file)
-    return ostream
+    return stdout
 
 def run(paths, file_extensions, style, config):
     '''
@@ -79,10 +71,11 @@ def run(paths, file_extensions, style, config):
     for path in paths:
         for root, dirs, files in walk(path):
             for file in files:
+                file_path = root+'/'+file
                 if (any([file.endswith(extension) for extension in file_extensions])):
-                    diff = diff_with_formatted_source(root+'/'+file, style)
+                    diff = diff_with_formatted_source(file_path, style)
                     if diff:
-                        diffs[root+'/'+file] = diff
+                        diffs[file_path] = diff
     return diffs
 
 if __name__ == '__main__':
@@ -100,7 +93,7 @@ if __name__ == '__main__':
                 print('####', file, '####')
                 print(diff.decode('utf-8'))
         print('Bad format')
-        exit(1)
     else:
         print('OK')
-        exit(0)
+    reformatted_files = len(diffs)
+    exit(reformatted_files)


### PR DESCRIPTION
configure with `-D ENABLE_AUTO_FORMAT=ON`

execute

``` bash
$ make format-cpp
$ make format-python
```

prints the diff if invoking clang-format or autopep8 would change
the file.
does NOT apply them though.
