### PR TITLE
Add put_child() to PropertyTree wrappers

### DIFF
--- a/python/source/wrappers/export_property_tree.cc
+++ b/python/source/wrappers/export_property_tree.cc
@@ -77,6 +77,7 @@ void export_property_tree()
     .def("parse_json", &pycap::parse_json, parse_docstring("JSON").c_str(), boost::python::args("self", "filename") )
     .def("parse_info", &pycap::parse_info, parse_docstring("INFO").c_str(), boost::python::args("self", "filename") )
     .def("get_child", &pycap::get_child, "Get the child at the given path, or throw ptree_bad_path.", boost::python::args("self", "path") )
+    .def("put_child", &pycap::put_child, "Put the child at the given path, create any missing parents, replace if it already exists.", boost::python::args("self", "path", "PropertyTree") )
     .def_pickle(pycap::serializable_class_pickle_support<boost::property_tree::ptree>())
         ;
   boost::python::register_ptr_to_python<std::shared_ptr<boost::property_tree::ptree>>();

--- a/python/source/wrappers/property_tree_wrappers.cc
+++ b/python/source/wrappers/property_tree_wrappers.cc
@@ -133,4 +133,9 @@ boost::property_tree::ptree get_child(boost::property_tree::ptree & ptree, strin
     return ptree.get_child(path);
 }
 
+void put_child(boost::property_tree::ptree & ptree, string const & path, boost::property_tree::ptree const & child)
+{
+    ptree.put_child(path, child);
+}
+
 } // end namespace pycap

--- a/python/source/wrappers/property_tree_wrappers.h
+++ b/python/source/wrappers/property_tree_wrappers.h
@@ -41,6 +41,7 @@ void parse_json(boost::property_tree::ptree & ptree, string const & filename);
 void parse_info(boost::property_tree::ptree & ptree, string const & filename);
 
 boost::property_tree::ptree get_child(boost::property_tree::ptree & ptree, string const & path);
+void put_child(boost::property_tree::ptree & ptree, string const & path, boost::property_tree::ptree const & child);
 
 template <typename T>
 struct serializable_class_pickle_support : boost::python::pickle_suite

--- a/python/test/test_property_tree_wrappers.py
+++ b/python/test/test_property_tree_wrappers.py
@@ -104,7 +104,7 @@ class boostPropertyTreePythonWrappersTestCase(unittest.TestCase):
                           'some.path.to.a.string')
 
     def test_parsers(self):
-        # populate a populate property tree from an input file
+        # populate a property tree from an input file
         ptree = PropertyTree()
         # INFO parser
         info_file = 'input.info'

--- a/python/test/test_property_tree_wrappers.py
+++ b/python/test/test_property_tree_wrappers.py
@@ -80,8 +80,14 @@ class boostPropertyTreePythonWrappersTestCase(unittest.TestCase):
         ptree.put_bool('is.that.a.good.idea', False)
         self.assertEqual(ptree.get_bool('is.that.a.good.idea'), False)
 
-    def test_get_child(self):
+    def test_get_children(self):
         ptree = PropertyTree()
+        # put child
+        child = PropertyTree()
+        child.put_double('prune', 6.10)
+        ptree.put_child('a.g', child)
+        self.assertEqual(ptree.get_double('a.g.prune'), 6.10)
+        # get child
         ptree.put_string('child.name', 'clement')
         ptree.put_int('child.age', -2)
         child = ptree.get_child('child')

--- a/python/test/test_property_tree_wrappers.py
+++ b/python/test/test_property_tree_wrappers.py
@@ -5,6 +5,7 @@
 # for the text and further information on this license. 
 
 from pycap import PropertyTree
+from os import remove
 import unittest
 
 
@@ -96,10 +97,37 @@ class boostPropertyTreePythonWrappersTestCase(unittest.TestCase):
         self.assertRaises(RuntimeError, ptree.get_double,
                           'some.path.to.a.string')
 
-    # TODO
-    def test_parse(self):
+    def test_parsers(self):
+        # populate a populate property tree from an input file
         ptree = PropertyTree()
-        ptree.parse_xml('device.xml')
+        # INFO parser
+        info_file = 'input.info'
+        today = 'april 8th, 2016'
+        with open(info_file, 'w') as fout:
+            fout.write('date "'+today+'"')
+        ptree.parse_info(info_file)
+        self.assertEqual(ptree.get_string('date'), today)
+        remove(info_file)
+        # XML parser
+        xml_file = 'input.xml'
+        pi = 3.14
+        with open(xml_file, 'w') as fout:
+            fout.write('<pi>'+str(pi)+'</pi>')
+        ptree.parse_xml(xml_file)
+        self.assertEqual(ptree.get_double('pi'), pi)
+        remove(xml_file)
+        # JSON parser
+        json_file = 'input.json'
+        with open(json_file, 'w') as fout:
+            fout.write('{')
+            fout.write('  "foo":')
+            fout.write('  {')
+            fout.write('    "bar": false')
+            fout.write('  }')
+            fout.write('}')
+        ptree.parse_json(json_file)
+        self.assertFalse(ptree.get_bool('foo.bar'))
+        remove(json_file)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This add a new feature to `pycap.PropertyTree` and enable to write code like:

``` python
super_capacitor_ptree.put_child('geometry', geometry_ptree)
super_capacitor_ptree.put_child('material_properties', material_properties_ptree)
```

It should also bring the coverage to 100% in `python/source/wrappers/property_tree_wrappers.cc`
