### PR TITLE
Check return code of diff is greater than 1

### DIFF
--- a/diff-clang-format.py
+++ b/diff-clang-format.py
@@ -47,7 +47,7 @@ def diff_with_formatted_source(original_file, style, patch):
     cmd = ['diff', formatted_file, original_file]
     p = Popen(cmd, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
-    if p.returncode or stderr:
+    if p.returncode > 1 or stderr:
         print(cmd)
         print(stderr.decode('utf-8'))
         raise RuntimeError('diff failed')


### PR DESCRIPTION
It seems that in some implementations of `diff`:
- 0 No differences were found
- 1 Differences were found
- >1 An error occurred
