### PR TITLE
Setup Jupyter cluster for running with MPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV NB_UID 1000
 
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir /home/$NB_USER/.jupyter && \
+    mkdir -p /home/$NB_USER/.ipython/profile_mpi && \
     mkdir /home/$NB_USER/.local && \
     mkdir /home/$NB_USER/notebooks && \
     chown -R $NB_USER:users /home/$NB_USER
@@ -49,4 +50,6 @@ CMD ["start-notebook.sh"]
 COPY docker/start-notebook.sh /usr/local/bin/
 COPY docker/jupyter_notebook_config.py /home/$NB_USER/.jupyter/
 COPY docker/jupyter_nbconvert_config.py /home/$NB_USER/.jupyter/
+COPY docker/ipengine_config.py /home/$NB_USER/.ipython/profile_mpi/
+COPY docker/ipcluster_config.py /home/$NB_USER/.ipython/profile_mpi/
 RUN chown -R $NB_USER:users /home/$NB_USER/.jupyter

--- a/docker/ipcluster_config.py
+++ b/docker/ipcluster_config.py
@@ -1,0 +1,4 @@
+import os
+c.IPClusterEngines.engine_launcher_class = 'MPI'
+if 'NPROC' in os.environ:
+    c.IPClusterEngines.n = int(os.environ['NPROC'])

--- a/docker/ipcluster_config.py
+++ b/docker/ipcluster_config.py
@@ -1,4 +1,4 @@
 import os
 c.IPClusterEngines.engine_launcher_class = 'MPI'
-if 'NPROC' in os.environ:
-    c.IPClusterEngines.n = int(os.environ['NPROC'])
+if 'JPY_ENGINES' in os.environ:
+    c.IPClusterEngines.n = int(os.environ['JPY_ENGINES'])

--- a/docker/ipengine_config.py
+++ b/docker/ipengine_config.py
@@ -1,0 +1,1 @@
+c.MPI.use = 'mpi4py'

--- a/python/source/__init__.py
+++ b/python/source/__init__.py
@@ -29,14 +29,14 @@ __doc__ = PyCap.__doc__
 
 # Override EnergyStorageDevice.__init__(...) to add a default value to the
 # ``comm`` parameter.
-def build(self, ptree, comm=MPI.COMM_WORLD):
+def build(self, ptree, comm=MPI.COMM_SELF):
     """
     Parameters
     ----------
     ptree : pycap.PropertyTree
         Property Tree
     comm : mpi4py.MPI.Comm
-        Communicator
+        Communicator (the default value is mpi4py.MPI.COMM_SELF).
     """
     return EnergyStorageDevice.build(self, ptree, comm)
 


### PR DESCRIPTION
- Added mpi profile for ipyparallel.
- Made `MPI.COMM_SELF` the default parameter in the `EnergyStorageDevice` constructor
