### PR TITLE
Add an include path for cppcheck

### DIFF
--- a/docker/build_jenkins.sh
+++ b/docker/build_jenkins.sh
@@ -35,4 +35,11 @@ make -j${NPROC} -i
 export LD_LIBRARY_PATH=${BOOST_DIR}/lib:${LD_LIBRARY_PATH}
 ctest -j${NPROC} --no-compress-output -T Test
 
-cppcheck --std=c++11 --enable=all --inconclusive --xml --xml-version=2 ../cpp 2> cppcheck.xml
+cppcheck \
+    --std=c++11 \
+    --enable=all \
+    --inconclusive \
+    --xml --xml-version=2 \
+    -I ../cpp/source/dummy \
+    -I ../cpp/source/deal.II/dummy \
+    ../cpp 2> cppcheck.xml


### PR DESCRIPTION
Not adding Boost not deal.II include paths because checking time goes through
the roof when I do

NOTE: please wait for me to check on Jenkins before you merge
