### PR TITLE
Show metadata from Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ web browser. PyCap makes it possible to create and manipulate Cap
 without the need to constantly recompile.
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/dalg24/cap.svg)](https://hub.docker.com/r/dalg24/cap)
-[![ImageLayers Size](https://img.shields.io/imagelayers/image-size/dalg24/cap-stack/latest.svg)]()
+[![Image Layers](https://images.microbadger.com/badges/image/dalg24/cap.svg)](http://microbadger.com/images/dalg24/cap)
 
 Authors
 -------


### PR DESCRIPTION
I was never able to get our previous badge by `imagelayers.io` working properly.
MicroBadger seems pretty straightforward to setup. I added a webhook to update
the badge when an autameted build happen on Docker Hub. I didn't even have to
create an account or anything which is great!
