### PR TITLE
Generate geometry

### DIFF
--- a/cpp/source/deal.II/geometry.h
+++ b/cpp/source/deal.II/geometry.h
@@ -15,6 +15,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <set>
 
 namespace cap
@@ -118,6 +119,22 @@ private:
    */
   void convert_geometry_database(
       std::shared_ptr<boost::property_tree::ptree> database);
+
+  /**
+   * Merge a triangulation that is repeated multiple times with the current
+   * triangulation.
+   */
+  void merge_repetition(dealii::distributed::Triangulation<dim> &repetition,
+                        double offset);
+
+  /**
+   * Compute the length of the triangulation along @dimension. Cells which have
+   * material_id in the set @excluded_materials are skipped.
+   */
+  double compute_length(
+      dealii::distributed::Triangulation<dim> const &triangulation,
+      unsigned int dimension,
+      std::unordered_set<dealii::types::material_id> const &excluded_materials);
 
   /**
    * Create a mesh from a property tree.


### PR DESCRIPTION
This is a partial improvement on the mesh that is generated using deal.II. Instead of adding a layer at the time when doing a repetition, an entire sandwich is added. This could be further improved using a tree-like merging method but this would be harder to do because we need to keep track of the position of each component. The setup (which does more than merging the triangulations) for 15 repetitions went from 8 s to 2.8 s
