### PR TITLE
Use matching building type for cap and deal.II

### DIFF
--- a/cmake/SetupTPLs.cmake
+++ b/cmake/SetupTPLs.cmake
@@ -44,4 +44,15 @@ endif()
 if(ENABLE_DEAL_II)
     find_package(deal.II 8.4 REQUIRED PATHS ${DEAL_II_DIR})
     add_definitions(-DWITH_DEAL_II)
+    # If deal.II was configured in DebugRelease mode, then if Cap was configured
+    # in Debug mode, we link against the Debug version of deal.II. IF Cap was
+    # configured in Release mode, we link against the Release version of deal.II
+    string(FIND "${DEAL_II_LIBRARIES}" "general" SINGLE_DEAL_II)
+    if (${SINGLE_DEAL_II} EQUAL -1)
+        if(CMAKE_BUILD_TYPE MATCHES "Release")
+            set(DEAL_II_LIBRARIES ${DEAL_II_LIBRARIES_RELEASE})
+        else()
+            set(DEAL_II_LIBRARIES ${DEAL_II_LIBRARIES_DEBUG})
+      endif()
+    endif()
 endif()


### PR DESCRIPTION
This works but doesn't fix the bug I have when using the release mode. However, the paths looks correct when using `ldd`.